### PR TITLE
update docker-compose files to use postgres 2.6.3

### DIFF
--- a/docker/docker-compose-devel.yml
+++ b/docker/docker-compose-devel.yml
@@ -85,7 +85,7 @@ services:
       - database
 
   database:
-    image: "postgres:9.4.11-alpine"
+    image: "postgres:9.6.3-alpine"
     restart: always
     env_file: ./docker-compose.env
 

--- a/docker/docker-compose-prod.yml
+++ b/docker/docker-compose-prod.yml
@@ -77,7 +77,7 @@ services:
       - database
 
   database:
-    image: "postgres:9.4.11-alpine"
+    image: "postgres:9.6.3-alpine"
     restart: always
     env_file: ./docker-compose.env
 


### PR DESCRIPTION
On a prod system, we will use postgres 2.6.3.
To be as close to production as possible, this updates the postgres version.