### PR TITLE
remove duplicated and mostly deprecated propel yml config file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 ./docker/docker-compose*
 vendor
 scripts
+config/Zed/propel*.yml


### PR DESCRIPTION
The command propel:pg-sql-compat is the only command, yet known, which
prefers the config from the `config/Zed/propel.yml` over the settings in
`config/Shared/*.php`. So we should avoid to have two places which need
maintenance.
If we drop the file, `propel:pg-sql-compat` is using the values from
`config/Shared/*.php`