### PR TITLE
docker-compose up/down volume fix

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       --requirepass $YVES_SESSION_REDIS_PASSWORD
       --appendonly yes
     volumes:
-      - /data
+      - yves-session-redis-data:/data
 
   zed-session-redis:
     image: "redis:4.0.9-alpine"
@@ -128,7 +128,7 @@ services:
       --requirepass $ZED_SESSION_REDIS_PASSWORD
       --appendonly yes
     volumes:
-      - /data
+      - zed-session-redis-data:/data
 
   storage-redis:
     image: "redis:4.0.9-alpine"
@@ -136,14 +136,14 @@ services:
       --requirepass $STORAGE_REDIS_PASSWORD
       --appendonly yes
     volumes:
-      - /data
+      - storage-redis-data:/data
 
   elasticsearch:
     image: "elasticsearch:5.6.9-alpine"
     ports:
       - "${BASE_PORT:-1}0500:9200"
     volumes:
-      - /usr/share/elasticsearch/data
+      - elasticsearch-data::/usr/share/elasticsearch/data
 
   database:
     image: "postgres:9.6.9-alpine"
@@ -153,7 +153,7 @@ services:
       POSTGRES_PASSWORD: "$ZED_DATABASE_PASSWORD"
       POSTGRES_USER: "spryker"
     volumes:
-      - /var/lib/postgresql/data
+      - database-data:/var/lib/postgresql/data
 
   jenkins:
     image: "jenkins/jenkins:lts-alpine"
@@ -163,7 +163,7 @@ services:
       JAVA_OPTS: "-Djava.awt.headless=true -Djenkins.install.runSetupWizard=false"
       JENKINS_OPTS: "-remoting"
     volumes:
-      - /var/jenkins_home
+      - jenkins-data:/var/jenkins_home
 
   jenkins-slave:
     <<: *x-jenkins-build
@@ -180,3 +180,18 @@ services:
       RABBITMQ_DEFAULT_USER: "spryker"
       RABBITMQ_DEFAULT_PASS: "$RABBITMQ_PASSWORD"
       RABBITMQ_DEFAULT_VHOST: "spryker"
+
+
+volumes:
+  database-data:
+    name: database-${ENV}-data
+  yves-session-redis-data:
+    name: yves-session-redis-${ENV}-data
+  zed-session-redis-data:
+    name: zed-session-redis-${ENV}-data    
+  storage-redis-data:
+    name: storage-redis-${ENV}-data      
+  jenkins-data:
+    name: jenkins-${ENV}-data
+  elasticsearch-data:
+    name: elasticsearch-${ENV}-data    


### PR DESCRIPTION
If you use `docker/run [devel, prod] up` or `down` (usually in docker-compose world), it deletes the created volume.

This update creates and uses a volume based on ENV so you do not have to end with CTRL-C. Now you can work up and down.